### PR TITLE
Fix false positives caused by inappropriate use of auto traits

### DIFF
--- a/src/exclude.rs
+++ b/src/exclude.rs
@@ -1,4 +1,4 @@
-use crate::{Nil, Cons};
+use crate::{Nil, Cons, HList};
 
 /// Marker trait that indicates that `HList` doesn't include type `T`
 ///
@@ -26,14 +26,30 @@ impl<T> Exclude<T> for Nil {}
 
 impl<H, T, E> Exclude<E> for Cons<H, T>
 where
-    (H, E): private::TypeNeq,
+    Pair<H, E>: private::TypeNeq,
     T: Exclude<E>
 {}
 
+/// `Pair` is being used instead of `(_, _)` to prevent false negative errors with types those
+/// include `(T, T)` themselves (e.g.: `(i32, i32)`). See [#4] & test `hlist_with_tuple2` down
+/// below for more.
+///
+/// [#4]: https://github.com/WaffleLapkin/minihlist/issues/4
+struct Pair<A, B>(A, B);
+
 mod private {
-    /// Marker trait **not** implemented for tuple of the same types - `(T, T)`.
+    /// Marker trait **not** implemented for pair of the same types - `Pair<T, T>`.
     ///
-    /// If `(A, B): TypeNeq` then `A` != `B`
+    /// If `Pair<A, B>: TypeNeq` then `A` != `B`
     pub auto trait TypeNeq {}
-    impl<T> !TypeNeq for (T, T) {}
+    impl<T> !TypeNeq for super::Pair<T, T> {}
+}
+
+/// Test for issue [#4](https://github.com/WaffleLapkin/minihlist/issues/4)
+#[test]
+fn hlist_with_tuple2() {
+    fn assert<T: Exclude<E>, E>() {}
+
+    type DefinitelyNotATuple = u64;
+    assert::<HList![(i32, i32)], DefinitelyNotATuple>();
 }

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -1,15 +1,4 @@
-use crate::{Cons, Nil, Extend};
-
-/// Trait implemented for all types except [`Cons`] and [`Nil`].
-/// It is needed to implement traits differently for `HList`s and for other types.
-/// (e.g.: [`Flatten`] is implemented using this trait)
-///
-/// [`Cons`]: crate::Cons
-/// [`Nil`]: crate::Nil
-#[cfg_attr(docsrs, doc(cfg(feature = "nightly")))]
-pub auto trait NotHList {}
-impl !NotHList for Nil {}
-impl<H, T> !NotHList for Cons<H, T> {}
+use crate::{Cons, Nil, Extend, HList};
 
 ///
 #[cfg_attr(docsrs, doc(cfg(feature = "nightly")))]
@@ -19,7 +8,11 @@ pub trait Flatten {
     fn flatten(self) -> Self::Output;
 }
 
-impl<H: NotHList, T: Flatten> Flatten for Cons<H, T> {
+impl<H, T> Flatten for Cons<H, T>
+where
+    Is<H>: NotHList,
+    T: Flatten,
+{
     type Output = Cons<H, T::Output>;
 
     fn flatten(self) -> Self::Output {
@@ -28,7 +21,10 @@ impl<H: NotHList, T: Flatten> Flatten for Cons<H, T> {
     }
 }
 
-impl<T: Flatten> Flatten for Cons<Nil, T> {
+impl<T> Flatten for Cons<Nil, T>
+where
+    T: Flatten,
+{
     type Output = T::Output;
 
     fn flatten(self) -> Self::Output {
@@ -36,9 +32,10 @@ impl<T: Flatten> Flatten for Cons<Nil, T> {
     }
 }
 
-impl<HH, HT, T: Flatten> Flatten for Cons<Cons<HH, HT>, T>
+impl<HH, HT, T> Flatten for Cons<Cons<HH, HT>, T>
 where
-    Cons<HH, HT>: Extend<T::Output>
+    Cons<HH, HT>: Extend<T::Output>,
+    T: Flatten,
 {
     type Output = <Cons<HH, HT> as Extend<T::Output>>::Output;
 
@@ -56,6 +53,23 @@ impl Flatten for Nil {
     }
 }
 
+/// Trait implemented for all types except `Is<`[`Cons`]`>` and `Is<`[`Nil`]`>`.
+/// It is needed to implement traits differently for `HList`s and for other types.
+/// (e.g.: [`Flatten`] is implemented using this trait)
+///
+/// [`Cons`]: crate::Cons
+/// [`Nil`]: crate::Nil
+auto trait NotHList {}
+impl !NotHList for Is<Nil> {}
+impl<H, T> !NotHList for Is<Cons<H, T>> {}
+
+/// `Is` is being used to prevent false negative errors with types those include `Nil` or
+/// `Cons<_, _>` (e.g.: `struct Test(Nil)`). See [#3] & test `hlist_with_hlist_inside_struct` down
+/// below for more.
+///
+/// [#3]: https://github.com/WaffleLapkin/minihlist/issues/3
+struct Is<T>(T);
+
 #[test]
 fn test() {
     use crate::hlist;
@@ -64,5 +78,20 @@ fn test() {
     assert_eq!(
         hlist.flatten().flatten(),
         hlist![1, 2, 3, 4, 5, 6, 7, 8, 9]
+    );
+}
+
+/// Test for issue [#3](https://github.com/WaffleLapkin/minihlist/issues/3)
+#[test]
+fn hlist_with_hlist_inside_struct() {
+    use crate::hlist;
+
+    #[derive(Debug, PartialEq)]
+    struct Wrap(Nil);
+
+    let hlist = hlist![Wrap(Nil), hlist![8]];
+    assert_eq!(
+        hlist.flatten(),
+        hlist![Wrap(Nil), 8]
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use len::Len;
 
 #[cfg(feature = "nightly")]
 pub use self::{
-    flatten::{Flatten, NotHList},
+    flatten::Flatten,
     exclude::Exclude,
     uniq::Unique,
 };

--- a/src/uniq.rs
+++ b/src/uniq.rs
@@ -28,3 +28,11 @@ impl<H, T> Unique for Cons<H, T>
 where
     T: Exclude<H> + Unique,
 {}
+
+/// Test for issue [#4](https://github.com/WaffleLapkin/minihlist/issues/4)
+#[test]
+fn hlist_with_tuple2() {
+    fn assert<T: Unique>() {}
+
+    assert::<crate::HList![String, (i32, i32)]>();
+}


### PR DESCRIPTION
This PR also removes `NotHList` from public api.

Fixes #3 
Fixes #4 