### PR TITLE
Make CI nicer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 name: Continuous integration
 
 jobs:
-  ci:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,71 +17,70 @@ jobs:
           - stable
           - beta
           - nightly
+    
+        include:
+          - rust: stable
+            features: "--features typenum,serde"
+          - rust: beta
+            features: "--features typenum,serde"
+          - rust: nightly
+            features: "--all-features"
 
     steps:
       - uses: actions/checkout@v1
         
       - uses: actions-rs/toolchain@v1
-        if: matrix.rust == 'stable' || matrix.rust == 'beta'
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          override: true
+      
+      - name: build 
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose ${{ matrix.features }}
+      
+      - name: test 
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose ${{ matrix.features }}
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
           override: true
           components: clippy
 
-      - uses: actions-rs/toolchain@v1
-        if: matrix.rust == 'nightly'
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
-      
-      - name: stable/beta build 
+      - name: clippy
         uses: actions-rs/cargo@v1
-        if: matrix.rust == 'stable' || matrix.rust == 'beta'
-        with:
-          command: build
-          args: --verbose --features "typenum,serde"
-      
-      - name: nightly build 
-        uses: actions-rs/cargo@v1
-        if: matrix.rust == 'nightly'
-        with:
-          command: build
-          args: --verbose --all-features
-      
-      - name: stable/beta test 
-        uses: actions-rs/cargo@v1
-        if: matrix.rust == 'stable' || matrix.rust == 'beta'
-        with:
-          command: test
-          args: --verbose --features "typenum,serde"
-      
-      - name: nightly test
-        uses: actions-rs/cargo@v1
-        if: matrix.rust == 'nightly'
-        with:
-          command: test
-          args: --verbose --all-features
-      
-      - name: stable/beta clippy
-        uses: actions-rs/cargo@v1
-        if: matrix.rust == 'stable' || matrix.rust == 'beta'
-        with:
-          command: clippy
-          args: --all-targets --features "typenum,serde" -- -D warnings
-      
-      - name: nightly clippy
-        uses: actions-rs/cargo@v1
-        if: matrix.rust == 'nightly'
         with:
           command: clippy
           args: --all-targets --all-features -- -D warnings
-      
+
+  style:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
       - name: fmt
         uses: actions-rs/cargo@v1
-        if: matrix.rust == 'nightly'
         with:
           command: fmt
           args: --all -- --check 


### PR DESCRIPTION
- Use `matrix.include` instead of `if matrix.rust == ...` to (dis)enable `nightly` feature
- move `clippy` and `fmt` to different jobs (and run both only on nighly)