### PR TITLE
implement type directed search

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -1,0 +1,58 @@
+use crate::{
+    succnum::{Succ, Zero},
+    Cons,
+};
+
+/// Type-directed search in hlist.
+///
+/// This trait allows to borrow elements from a hlist just by type.
+///
+/// ## Examples
+///
+/// ```
+/// use minihlist::{hlist, Get};
+///
+/// let mut list = hlist![1, 'x'];
+///
+/// let i: &i32 = list.get();
+/// assert_eq!(i, &1);
+///
+/// *list.get_mut() = 'y';
+/// assert_eq!(list, hlist![1, 'y']);
+/// ```
+///
+/// Note that you can't borrow elements those are not unique:
+/// ```compile_fail,E0282
+/// use minihlist::{hlist, Get};
+///
+/// let list = hlist![17, 42];
+/// let _: &i32 = list.get();
+/// ```
+pub trait Get<Idx, Out> {
+    fn get(&self) -> &Out;
+
+    fn get_mut(&mut self) -> &mut Out;
+}
+
+impl<H, T> Get<Zero, H> for Cons<H, T> {
+    fn get(&self) -> &H {
+        &self.0
+    }
+
+    fn get_mut(&mut self) -> &mut H {
+        &mut self.0
+    }
+}
+
+impl<H, T, Idx, Out> Get<Succ<Idx>, Out> for Cons<H, T>
+where
+    T: Get<Idx, Out>,
+{
+    fn get(&self) -> &Out {
+        self.1.get()
+    }
+
+    fn get_mut(&mut self) -> &mut Out {
+        self.1.get_mut()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,9 @@ mod local_macros;
 
 mod append;
 mod extend;
+mod get;
 mod hlist;
+mod remove;
 mod rev;
 mod small;
 mod tuple;
@@ -82,7 +84,8 @@ mod exclude;
 mod len;
 
 pub use self::{
-    append::Append, extend::Extend, hlist::HList, rev::Rev, small::SmallHList, tuple::Tuple,
+    append::Append, extend::Extend, get::Get, hlist::HList, remove::Remove, rev::Rev,
+    small::SmallHList, tuple::Tuple,
 };
 
 #[cfg(feature = "typenum")]
@@ -290,4 +293,10 @@ macro_rules! HList {
     };
     ($head:ty) => { $crate::HList![$head,] /* redirect to previous branch */ };
     () => { $crate::Nil };
+}
+
+/// Minimalistic analog to crates like `peano` and `typenum`
+mod succnum {
+    pub enum Zero {}
+    pub struct Succ<I>(I);
 }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,0 +1,56 @@
+use crate::{
+    succnum::{Succ, Zero},
+    Cons, Get,
+};
+
+/// Type-directed search & remove in hlist.
+///
+/// This trait is very simlar to [`Get`](crate::Get) but instead of borrowing, it allows to remove
+/// elements from a hlist just by type.
+///
+/// ## Examples
+///
+/// ```
+/// use minihlist::{hlist, Remove};
+///
+/// let mut list = hlist![1, 'x'];
+///
+/// let (i, rest): (i32, _) = list.remove();
+/// assert_eq!(i, 1);
+/// assert_eq!(rest, hlist!['x']);
+/// ```
+///
+/// Note that just like with [`Get`] you can't remove elements those are not unique:
+/// ```compile_fail,E0282
+/// use minihlist::{hlist, Remove};
+///
+/// let list = hlist![17, 42];
+/// let (_, _): (i32, _) = list.remove();
+/// ```
+pub trait Remove<Idx, Out>: Get<Idx, Out> {
+    type Rest;
+
+    fn remove(self) -> (Out, Self::Rest);
+}
+
+impl<H, T> Remove<Zero, H> for Cons<H, T> {
+    type Rest = T;
+
+    fn remove(self) -> (H, Self::Rest) {
+        let Cons(head, tail) = self;
+        (head, tail)
+    }
+}
+
+impl<H, T, Idx, Out> Remove<Succ<Idx>, Out> for Cons<H, T>
+where
+    T: Remove<Idx, Out>,
+{
+    type Rest = Cons<H, T::Rest>;
+
+    fn remove(self) -> (Out, Self::Rest) {
+        let Cons(head, tail) = self;
+        let (ret, tail_rest) = tail.remove();
+        (ret, Cons(head, tail_rest))
+    }
+}


### PR DESCRIPTION
Implement type directed search by 2 traits: `Get` (borrowing) and `Remove` (moving)