### PR TITLE
loose bound on `Partial{Eq,Ord}` impls for `Cons`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub struct Nil;
 /// An `HList` with `H` at position 0, and `T` as the rest of the list.
 ///
 /// See [crate documentation](./index.html) for more.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+#[derive(Clone, Copy, Eq, Ord, Hash, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cons<H, T>(pub H, pub T);
 
@@ -152,6 +152,29 @@ impl<H, T> Cons<H, T> {
     pub fn pop(self) -> (H, T) {
         let Self(head, tail) = self;
         (head, tail)
+    }
+}
+
+impl<RH, RT, H, T> PartialEq<Cons<RH, RT>> for Cons<H, T>
+where
+    H: PartialEq<RH>,
+    T: PartialEq<RT>,
+{
+    fn eq(&self, other: &Cons<RH, RT>) -> bool {
+        self.0 == other.0 && self.1 == other.1
+    }
+}
+
+impl<RH, RT, H, T> PartialOrd<Cons<RH, RT>> for Cons<H, T>
+where
+    H: PartialOrd<RH>,
+    T: PartialOrd<RT>,
+{
+    fn partial_cmp(&self, other: &Cons<RH, RT>) -> Option<core::cmp::Ordering> {
+        match self.0.partial_cmp(&other.0) {
+            None | Some(core::cmp::Ordering::Equal) => self.1.partial_cmp(&other.1),
+            res @ Some(_) => res,
+        }
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -48,7 +48,7 @@ use crate::{pure, Cons, Nil};
 ///     |f| (f * 2.) as i32,
 ///     &mut |i| format!("{}", i), // <-- `FnMut` here
 /// ]);
-/// assert_eq!(res, hlist![3, String::from("12"), String::from("16")]);
+/// assert_eq!(res, hlist![3, "12", "16"]);
 /// ```
 
 pub trait Map<F> {
@@ -148,5 +148,5 @@ fn mixed() {
         &mut |i| i * 2,
     ];
 
-    assert_eq!(list.map(f), hlist!['X', String::from("X"), 4, 8, 16]);
+    assert_eq!(list.map(f), hlist!['X', "X", 4, 8, 16]);
 }


### PR DESCRIPTION
Bounds before this PR:
```rust
// Note: by default `PartialEq` uses `Self` as `Rhs`
impl<H, T> PartialEq for Cons<H, T>
where
    H: PartialEq,
    T: PartialEq,
{ /* ... */ }
```

Bounds after this PR:
```rust
impl<RH, RT, H, T> PartialEq<Cons<RH, RT>> for Cons<H, T>
where
    H: PartialEq<RH>,
    T: PartialEq<RT>,
{ /* ... */ }
```
(same goes for `PartialOrd`)

pros/cons:
+: allows comparing `HList![String]` with `HList![&str]` (just an example)
-: disallows `match`ing with `const` patterns
-: could potentially break type inference in cases when you depend on `e == e'` => `E == E'` (which isn't true with such impl of `PartialEq`)