### PR TITLE
remove forbidden magic #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 typenum = { version = "1.0", optional = true }
 
 [features]
-## features those require nightly compiler
-#nightly = []
+# features those require nightly compiler
+nightly = []
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 typenum = { version = "1.0", optional = true }
 
 [features]
-# features those require nightly compiler
-nightly = []
+## features those require nightly compiler
+#nightly = []
 
 [package.metadata."docs.rs"]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@
 //!
 //!
 //! TODO
-#![cfg_attr(feature = "nightly", feature(optin_builtin_traits, negative_impls))]
 // we pass "--cfg docsrs" when building docs to add `This is supported on feature="..." only.`
 //
 // To properly build docs of this crate run
@@ -74,9 +73,6 @@ mod rfold;
 mod small;
 mod tuple;
 
-#[cfg(feature = "nightly")]
-mod flatten;
-
 #[cfg(feature = "typenum")]
 mod len;
 
@@ -87,9 +83,6 @@ pub use self::{
 
 #[cfg(feature = "typenum")]
 pub use len::Len;
-
-#[cfg(feature = "nightly")]
-pub use self::flatten::Flatten;
 
 /// The empty `HList`.
 ///


### PR DESCRIPTION
This "ad-hoc specialization hack using `optin_builtin_traits` and `negative_impls`"
was possible due to a soundness bug in rustc. (see rust-lang/rust#74629)

Flatten probably need `#[feature(specialization)]` to work, though specialization
doesn't work with associated items at the moment, so this needs more research.